### PR TITLE
Add truncate title to make sure the length of the title is at most 255

### DIFF
--- a/src/core/crons.py
+++ b/src/core/crons.py
@@ -226,10 +226,8 @@ class ZoteroImport(CronJobBase):
                     info.save()
                 except:
                     title = each["data"].get("title")
-                    # Truncate the title to make sure the title length does not exceed 255 characters
-                    truncated_title = title[:255]  
                     info = ZoteroItem.objects.create(
-                        title = truncated_title if truncated_title else "No title",
+                        title = title[:255] if title else "No title", # Truncate the title to make sure the title length does not exceed 255 characters
                         key = each["data"].get("key"),
                         data = each["data"],
                         collection = collection,

--- a/src/core/crons.py
+++ b/src/core/crons.py
@@ -226,8 +226,10 @@ class ZoteroImport(CronJobBase):
                     info.save()
                 except:
                     title = each["data"].get("title")
+                    # Truncate the title to make sure the title length does not exceed 255 characters
+                    truncated_title = title[:255]  
                     info = ZoteroItem.objects.create(
-                        title = title if title else "No title",
+                        title = truncated_title if truncated_title else "No title",
                         key = each["data"].get("key"),
                         data = each["data"],
                         collection = collection,


### PR DESCRIPTION
I added one line of checking the string length of the title to be at most 255 characters before inserting into the Zotero Item Library. 

@paulhoekman do you mind testing again to see if this check resolve the issue in the Zotero syncing process? Please let me know if there is any other errors. Thanks!